### PR TITLE
Add U64Vector TransactionArgument for vector<u64> support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.aptos-labs</groupId>
   <artifactId>japtos</artifactId>
-  <version>1.1.6</version>
+  <version>1.1.7</version>
 
 
   <developers>

--- a/src/main/java/com/aptoslabs/japtos/types/TransactionArgument.java
+++ b/src/main/java/com/aptoslabs/japtos/types/TransactionArgument.java
@@ -6,6 +6,7 @@ import com.aptoslabs.japtos.bcs.Serializer;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Represents a transaction argument.
@@ -189,6 +190,44 @@ public abstract class TransactionArgument implements Serializable {
 
         public byte[] getValue() {
             return value;
+        }
+    }
+
+    /**
+     * U64Vector argument for vector<u64> type
+     * Serializes as a uleb128 length followed by u64 values
+     */
+    public static class U64Vector extends TransactionArgument {
+        private final List<Long> values;
+
+        public U64Vector(List<Long> values) {
+            this.values = values;
+        }
+
+        @Override
+        public void serialize(Serializer serializer) throws IOException {
+            // Serialize vector length as ULEB128
+            serializer.serializeU32AsUleb128(values.size());
+            // Serialize each u64 value
+            for (Long value : values) {
+                serializer.serializeU64(value);
+            }
+        }
+        
+        @Override
+        public byte[] serializeForEntryFunction() throws IOException {
+            Serializer serializer = new Serializer();
+            // Serialize vector length as ULEB128
+            serializer.serializeU32AsUleb128(values.size());
+            // Serialize each u64 value
+            for (Long value : values) {
+                serializer.serializeU64(value);
+            }
+            return serializer.toByteArray();
+        }
+
+        public List<Long> getValue() {
+            return values;
         }
     }
 


### PR DESCRIPTION
## Summary
Adding another transaction type.
ts-sdk has a MoveVector type which the java sdk should probably move to in some ways - https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/transactions/types.ts#L64

## Test Plan
Probably would be good to have more tests setup here but i tested it by building locally with a decibel example
https://github.com/aptos-labs/etna/pull/1237