### PR TITLE
ci: add Maven Central publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,19 @@ on:
     branches: [main]
   pull_request:
 
+# CI only reads source and uploads coverage (codecov uses its own token).
+# No GitHub API writes required.
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -21,7 +26,7 @@ jobs:
       - name: Run unit tests
         run: mvn verify -P unit-tests -Dgpg.skip=true
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/site/jacoco/jacoco.xml
@@ -33,15 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 
@@ -73,7 +78,7 @@ jobs:
       - name: Run integration tests
         run: mvn verify -P integration-tests -Dgpg.skip=true
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/site/jacoco/jacoco.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
           cache: 'maven'
 
       - name: Run unit tests
-        run: mvn verify -P unit-tests -Dgpg.skip=true
-      - name: Upload coverage
+        run: mvn verify -P unit-tests      - name: Upload coverage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -76,8 +75,7 @@ jobs:
           exit 1
 
       - name: Run integration tests
-        run: mvn verify -P integration-tests -Dgpg.skip=true
-      - name: Upload coverage
+        run: mvn verify -P integration-tests      - name: Upload coverage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           cache: 'maven'
 
       - name: Run unit tests
-        run: mvn verify -P unit-tests      - name: Upload coverage
+        run: mvn verify -P unit-tests
+      - name: Upload coverage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -75,7 +76,8 @@ jobs:
           exit 1
 
       - name: Run integration tests
-        run: mvn verify -P integration-tests      - name: Upload coverage
+        run: mvn verify -P integration-tests
+      - name: Upload coverage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,15 @@
 # Trigger: a GitHub Release is published. The tag (e.g. v1.3.0) drives the version.
 #
 # Required repository secrets:
-#   CENTRAL_USERNAME    - Central Portal user token username (central.sonatype.com -> Account -> Generate User Token)
-#   CENTRAL_PASSWORD    - Central Portal user token password
-#   GPG_PRIVATE_KEY     - ASCII-armored GPG private key: `gpg --armor --export-secret-keys FA3B5E4A`
-#                         Key fingerprint must match <keyname> in pom.xml (currently FA3B5E4A).
-#   GPG_PASSPHRASE      - Passphrase for the GPG key
+#   CENTRAL_USERNAME      - Central Portal user token username (central.sonatype.com -> Account -> Generate User Token)
+#   CENTRAL_PASSWORD      - Central Portal user token password
+#   GPG_PRIVATE_KEY       - ASCII-armored GPG private key:
+#                             `gpg --armor --export-secret-keys <FULL_FINGERPRINT>`
+#                           Find the fingerprint via `gpg --list-secret-keys --keyid-format=long --fingerprint`.
+#   GPG_PASSPHRASE        - Passphrase for the GPG key
+#   GPG_KEY_FINGERPRINT   - Full 40-char fingerprint of the signing key (no spaces). Passed to
+#                           maven-gpg-plugin as -Dgpg.keyname to disambiguate the signing key.
+#                           Short key IDs are collision-prone and not used here.
 #
 # Optional: configure an Environment named `maven-central` in repo settings to add a
 # required-reviewer gate before any publish runs.
@@ -33,9 +37,11 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+      # Check out the release tag (immutable) rather than target_commitish (typically a branch
+      # name that can advance after the release is cut). Guarantees published bits == tagged commit.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: refs/tags/${{ github.event.release.tag_name }}
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -52,11 +58,11 @@ jobs:
         id: version
         run: |
           tag="${{ github.event.release.tag_name }}"
-          version="${tag#v}"
-          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Tag '$tag' is not a valid release version (expected vMAJOR.MINOR.PATCH)"
             exit 1
           fi
+          version="${tag#v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set release version in pom.xml
@@ -67,9 +73,12 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        # -DperformRelease=true activates the `release` profile in pom.xml,
-        # which enables GPG signing. Without this flag, no signing occurs.
-        run: mvn -B clean deploy -DskipTests -DperformRelease=true
+        # -DperformRelease=true activates the `release` profile in pom.xml (which enables GPG
+        # signing). -Dgpg.keyname uses the full fingerprint to unambiguously pick the signing key.
+        run: |
+          mvn -B clean deploy -DskipTests \
+            -DperformRelease=true \
+            -Dgpg.keyname="${{ secrets.GPG_KEY_FINGERPRINT }}"
 
   bump-version:
     name: Bump main to next SNAPSHOT
@@ -91,6 +100,7 @@ jobs:
 
       - name: Bump pom.xml to next SNAPSHOT
         run: |
+          set -euo pipefail
           current="${{ needs.publish.outputs.version }}"
           IFS='.' read -r major minor patch <<< "$current"
           next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
@@ -104,4 +114,22 @@ jobs:
           fi
           git add pom.xml
           git commit -m "chore: bump version to ${next} after ${current} release"
-          git push origin main
+
+          # main can advance while the publish job runs. Rebase + retry on push contention;
+          # bail loudly if a rebase conflict appears (means someone else also touched pom.xml).
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then
+              echo "Pushed bump on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt; fetching latest main and rebasing..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "::error::Rebase onto origin/main produced a conflict; manual intervention required"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+          echo "::error::Failed to push bump after 5 attempts"
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,9 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn -B clean deploy -DskipTests
+        # -DperformRelease=true activates the `release` profile in pom.xml,
+        # which enables GPG signing. Without this flag, no signing occurs.
+        run: mvn -B clean deploy -DskipTests -DperformRelease=true
 
   bump-version:
     name: Bump main to next SNAPSHOT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
+# Deny-all default; each job opts into only the scopes it needs.
+permissions: {}
 
 jobs:
   publish:
@@ -27,13 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: maven-central
+    # mvn deploy talks to Maven Central, not GitHub. Read-only token is enough for checkout.
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.release.target_commitish }}
-          fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -65,21 +69,37 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: mvn -B clean deploy -DskipTests
 
-      - name: Bump to next SNAPSHOT on main
+  bump-version:
+    name: Bump main to next SNAPSHOT
+    runs-on: ubuntu-latest
+    needs: publish
+    # Isolated from the deploy step so third-party Maven plugins never see a write-scoped token.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Bump pom.xml to next SNAPSHOT
         run: |
-          current="${{ steps.version.outputs.version }}"
+          current="${{ needs.publish.outputs.version }}"
           IFS='.' read -r major minor patch <<< "$current"
           next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
           mvn -B versions:set -DnewVersion="$next" -DgenerateBackupPoms=false
           if git diff --quiet pom.xml; then
             echo "pom.xml already at $next; nothing to commit"
             exit 0
           fi
           git add pom.xml
-          git commit -m "chore: bump version to ${next} after ${{ steps.version.outputs.version }} release"
+          git commit -m "chore: bump version to ${next} after ${current} release"
           git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+# Publishes japtos to Maven Central via the Central Portal.
+#
+# Trigger: a GitHub Release is published. The tag (e.g. v1.3.0) drives the version.
+#
+# Required repository secrets:
+#   CENTRAL_USERNAME    - Central Portal user token username (central.sonatype.com -> Account -> Generate User Token)
+#   CENTRAL_PASSWORD    - Central Portal user token password
+#   GPG_PRIVATE_KEY     - ASCII-armored GPG private key: `gpg --armor --export-secret-keys FA3B5E4A`
+#                         Key fingerprint must match <keyname> in pom.xml (currently FA3B5E4A).
+#   GPG_PASSPHRASE      - Passphrase for the GPG key
+#
+# Optional: configure an Environment named `maven-central` in repo settings to add a
+# required-reviewer gate before any publish runs.
+
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version="${tag#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$tag' is not a valid release version (expected vMAJOR.MINOR.PATCH)"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set release version in pom.xml
+        run: mvn -B versions:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Publish to Maven Central
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -B clean deploy -DskipTests
+
+      - name: Bump to next SNAPSHOT on main
+        run: |
+          current="${{ steps.version.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$current"
+          next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          mvn -B versions:set -DnewVersion="$next" -DgenerateBackupPoms=false
+          if git diff --quiet pom.xml; then
+            echo "pom.xml already at $next; nothing to commit"
+            exit 0
+          fi
+          git add pom.xml
+          git commit -m "chore: bump version to ${next} after ${{ steps.version.outputs.version }} release"
+          git push origin main

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,1 +1,0 @@
-mvn clean package javadoc:jar source:jar gpg:sign deploy -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <gson.version>2.10.1</gson.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <slf4j.version>2.0.9</slf4j.version>
+    <!-- Default GPG signing key for releases; override with -Dgpg.keyname=... -->
+    <gpg.keyname>FA3B5E4A</gpg.keyname>
   </properties>
 
   <dependencyManagement>
@@ -60,14 +62,14 @@
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>
     </dependency>
-    
+
     <!-- JSON Processing -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
-    
+
     <!-- Cryptography - Android compatible -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -84,14 +86,14 @@
       <artifactId>bcutil-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
-    
+
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
-    
+
     <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -114,42 +116,17 @@
   <build>
     <plugins>
 
+      <!-- Generates Constants.java from src/main/java-templates/ with ${project.version} interpolated.
+           Output goes to target/generated-sources/java-templates/ — the tracked template is never modified. -->
       <plugin>
-        <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>replacer</artifactId>
-        <version>1.5.3</version> <!-- Use a recent version -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
+            <id>filter-src</id>
             <goals>
-              <goal>replace</goal>
+              <goal>filter-sources</goal>
             </goals>
-            <configuration>
-              <file>src/main/java/com/aptoslabs/japtos/core/Constants.java</file>
-              <replacements>
-                <replacement>
-                  <token>@@PROJECT_VERSION</token>
-                  <value>${project.version}</value>
-                </replacement>
-              </replacements>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-            <configuration>
-               <keyname>FA3B5E4A</keyname>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -157,7 +134,6 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.9.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -165,38 +141,40 @@
         </configuration>
       </plugin>
 
+      <!-- Sources jar attached at default `package` phase so it exists before GPG signs at `verify`. -->
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
             <id>attach-sources</id>
-            <phase>deploy</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-            <additionalOptions>-Xdoclint:none</additionalOptions>
+          <additionalOptions>-Xdoclint:none</additionalOptions>
         </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>deploy</phase>
-            <goals><goal>jar</goal></goals>
+            <goals>
+              <goal>jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
 
     </plugins>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement><!-- lock down plugin versions to avoid Maven defaults -->
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.4.0</version>
         </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.3.1</version>
@@ -204,10 +182,6 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
-          <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -228,6 +202,23 @@
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.6.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.12.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>templating-maven-plugin</artifactId>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -297,6 +288,37 @@
                 <APTOS_NETWORK>LOCALNET</APTOS_NETWORK>
               </systemPropertyVariables>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- GPG signing only runs for releases. Activate with -DperformRelease=true (Maven convention,
+         also set automatically by maven-release-plugin). This keeps `mvn verify` fast for everyday
+         use and CI test runs — no more -Dgpg.skip=true workaround needed. -->
+    <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals><goal>sign</goal></goals>
+                <configuration>
+                  <keyname>${gpg.keyname}</keyname>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,10 @@
     <gson.version>2.10.1</gson.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <!-- Default GPG signing key for releases; override with -Dgpg.keyname=... -->
-    <gpg.keyname>FA3B5E4A</gpg.keyname>
+    <!-- GPG signing key. No default: pass the full 40-char fingerprint at release time
+         via -Dgpg.keyname=<fingerprint>. Short key IDs are collision-prone and are not
+         recommended for production signing configuration. -->
+    <gpg.keyname />
   </properties>
 
   <dependencyManagement>
@@ -219,6 +221,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>templating-maven-plugin</artifactId>
           <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.9.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>

--- a/src/main/java-templates/com/aptoslabs/japtos/core/Constants.java
+++ b/src/main/java-templates/com/aptoslabs/japtos/core/Constants.java
@@ -1,13 +1,9 @@
 package com.aptoslabs.japtos.core;
 
-/**
- * Constants for Japtos SDK
- */
 public class Constants {
-    public static final String VERSION = "1.1.7";
+    public static final String VERSION = "${project.version}";
     public static final String GITHUB_REPO = "https://github.com/aptos-labs/japtos";
-    
-    // Private constructor to prevent instantiation
+
     private Constants() {
         throw new AssertionError("Constants class should not be instantiated");
     }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` to automate publishing to Maven Central via the Central Portal, replacing the local `deploy.sh` flow.
- Trigger: **GitHub Release published**. The tag (e.g. `v1.3.0`) drives the published artifact version through `mvn versions:set`.
- After a successful deploy, the workflow bumps `pom.xml` on `main` to the next `-SNAPSHOT` (`1.3.1-SNAPSHOT` after a `v1.3.0` release) and pushes that commit back. `GITHUB_TOKEN` pushes don't re-trigger workflows, so CI doesn't double-run.
- Uses `actions/setup-java@v4`'s built-in `server-*` and `gpg-*` inputs to wire `~/.m2/settings.xml` and import the signing key — no manual `gpg --import` or settings templating.
- Job runs under `environment: maven-central` so you can add a required-reviewer gate in repo settings without changing the workflow.

## Required repository secrets (must be added before first release)
| Secret | Value |
|---|---|
| `CENTRAL_USERNAME` | Central Portal user token username from central.sonatype.com -> Account -> Generate User Token |
| `CENTRAL_PASSWORD` | Central Portal user token password |
| `GPG_PRIVATE_KEY`  | ASCII-armored export: `gpg --armor --export-secret-keys FA3B5E4A` (must match `<keyname>` in `pom.xml`) |
| `GPG_PASSPHRASE`   | Passphrase for the GPG key |

## Test plan
- [ ] Add the four secrets listed above to the repository
- [ ] (Optional) Configure the `maven-central` Environment in repo settings with required reviewers
- [ ] Cut a test release (e.g. `v1.2.1`) and confirm the artifact lands on Maven Central
- [ ] Confirm the post-publish bump commit appears on `main` with the next `-SNAPSHOT` version
- [ ] Confirm CI does **not** re-run from the bump commit